### PR TITLE
Fix Bad Access when creating predicate in CollectionView scroll until methods

### DIFF
--- a/Kava/Kava/Source/PageObjects/Infrastructure/Elements/CollectionView.swift
+++ b/Kava/Kava/Source/PageObjects/Infrastructure/Elements/CollectionView.swift
@@ -65,7 +65,7 @@ open class CollectionView<TResultBlock : Block> : Element {
     }
     
     open func scrollForwardUntil<TCustomResultBlock : Block>(_ block: @escaping (() -> Bool), timeout: TimeInterval = 5, result: TCustomResultBlock.Type, constructingBlock builder: (() -> TCustomResultBlock)? = nil) -> TCustomResultBlock {
-        let predicate = NSPredicate { (_: Any, _: [String : Any]?) -> Bool in
+        let predicate = NSPredicate { (_, _) -> Bool in
             return block()
         }
         return self.scrollForwardUntil(predicate, timeout: timeout, result: result, constructingBlock: builder)
@@ -85,7 +85,7 @@ open class CollectionView<TResultBlock : Block> : Element {
     }
     
     open func scrollBackwardsUntil<TCustomResultBlock : Block>(_ block: @escaping (() -> Bool), timeout: TimeInterval = 5, result: TCustomResultBlock.Type, constructingBlock builder: (() -> TCustomResultBlock)? = nil) -> TCustomResultBlock {
-        let predicate = NSPredicate { (_: Any, _: [String : Any]?) -> Bool in
+        let predicate = NSPredicate { (_, _) -> Bool in
             return block()
         }
         return self.scrollBackwardsUntil(predicate, timeout: timeout, result: result, constructingBlock: builder)

--- a/Kava/Kava/Source/PageObjects/Infrastructure/Elements/CollectionView.swift
+++ b/Kava/Kava/Source/PageObjects/Infrastructure/Elements/CollectionView.swift
@@ -65,7 +65,7 @@ open class CollectionView<TResultBlock : Block> : Element {
     }
     
     open func scrollForwardUntil<TCustomResultBlock : Block>(_ block: @escaping (() -> Bool), timeout: TimeInterval = 5, result: TCustomResultBlock.Type, constructingBlock builder: (() -> TCustomResultBlock)? = nil) -> TCustomResultBlock {
-        let predicate = NSPredicate { _ -> Bool in
+        let predicate = NSPredicate { _ in
             return block()
         }
         return self.scrollForwardUntil(predicate, timeout: timeout, result: result, constructingBlock: builder)
@@ -85,7 +85,7 @@ open class CollectionView<TResultBlock : Block> : Element {
     }
     
     open func scrollBackwardsUntil<TCustomResultBlock : Block>(_ block: @escaping (() -> Bool), timeout: TimeInterval = 5, result: TCustomResultBlock.Type, constructingBlock builder: (() -> TCustomResultBlock)? = nil) -> TCustomResultBlock {
-        let predicate = NSPredicate { _ -> Bool in
+        let predicate = NSPredicate { _ in
             return block()
         }
         return self.scrollBackwardsUntil(predicate, timeout: timeout, result: result, constructingBlock: builder)

--- a/Kava/Kava/Source/PageObjects/Infrastructure/Elements/CollectionView.swift
+++ b/Kava/Kava/Source/PageObjects/Infrastructure/Elements/CollectionView.swift
@@ -65,7 +65,7 @@ open class CollectionView<TResultBlock : Block> : Element {
     }
     
     open func scrollForwardUntil<TCustomResultBlock : Block>(_ block: @escaping (() -> Bool), timeout: TimeInterval = 5, result: TCustomResultBlock.Type, constructingBlock builder: (() -> TCustomResultBlock)? = nil) -> TCustomResultBlock {
-        let predicate = NSPredicate { (_, _) -> Bool in
+        let predicate = NSPredicate { _ -> Bool in
             return block()
         }
         return self.scrollForwardUntil(predicate, timeout: timeout, result: result, constructingBlock: builder)
@@ -85,7 +85,7 @@ open class CollectionView<TResultBlock : Block> : Element {
     }
     
     open func scrollBackwardsUntil<TCustomResultBlock : Block>(_ block: @escaping (() -> Bool), timeout: TimeInterval = 5, result: TCustomResultBlock.Type, constructingBlock builder: (() -> TCustomResultBlock)? = nil) -> TCustomResultBlock {
-        let predicate = NSPredicate { (_, _) -> Bool in
+        let predicate = NSPredicate { _ -> Bool in
             return block()
         }
         return self.scrollBackwardsUntil(predicate, timeout: timeout, result: result, constructingBlock: builder)


### PR DESCRIPTION
The types for unused parameters in an NSPredicate evaluation block were incorrect and will trigger a bad access when that predicate is evaluated.  This revision removes those types effectively fixing the `scrollBackwardsUntil(_ block...)` and `scrollForwardUntil(_ block...)` methods. 
